### PR TITLE
Add "No media" notice customization

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -24,6 +24,9 @@
         <entry name="separatorString" type="String">
             <default>|</default>
         </entry>
+        <entry name="noMediaString" type="String">
+            <default>No media</default>
+        </entry>
         
         <entry name="shouldUseDefaultThemeFontSize" type="Bool">
             <default>true</default>

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -12,6 +12,7 @@ Kirigami.FormLayout {
     property alias cfg_shouldAddTrailingWhitespaceToSeparator: shouldAddTrailingWhitespaceToSeparator.checked
     property alias cfg_characterLimit: characterLimit.text
     property alias cfg_separatorString: separatorString.text
+    property alias cfg_noMediaString: noMediaString.text
     property alias cfg_shouldUseDefaultThemeFontSize: shouldUseDefaultThemeFontSize.checked
     property alias cfg_configuredFontSize: configuredFontSize.text
 
@@ -46,6 +47,12 @@ Kirigami.FormLayout {
     TextField {
         id: separatorString
         Kirigami.FormData.label: i18n("Separator string:")
+        placeholderText: i18n("")
+    }
+
+    TextField {
+        id: noMediaString
+        Kirigami.FormData.label: i18n("Text to show when not playing any media (or no info is available):")
         placeholderText: i18n("")
     }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -49,7 +49,7 @@ Item {
     }
 
     property string oneLineTextContent: {
-        if (!metadata) return "No media"
+        if (!metadata) return plasmoid.configuration.noMediaString
         if (!trackTitle && !artist) return ""
 
         if (plasmoid.configuration.shouldDisplayTitleOnly)


### PR DESCRIPTION
This PR adds an option in the widget's configuration to customize the text that is shown when no info is available (this may be useful for people who don't want the widget to waste space when not in use, or as part of a more complex layout)

![image](https://user-images.githubusercontent.com/49426949/199006893-753328f8-ca7e-4ac0-b4ff-e5e12fe3b037.png)
